### PR TITLE
Add Python linting with ruff

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,0 +1,29 @@
+name: Python Linter & Formatter
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint_and_format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install ruff
+      run: pip install ruff
+
+    - name: Run Formatter Check
+      run: ruff format --check .
+
+    - name: Run Linter
+      run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.ruff]
+# Modern line length (not the old 79)
+line-length = 120
+
+# Use Python 3.13 (your current version)
+target-version = "py313"
+
+[tool.ruff.lint]
+# Enable good, non-annoying rules
+select = [
+    "E4",   # Import errors
+    "E7",   # Statement errors
+    "E9",   # Runtime errors
+    "F",    # Pyflakes (undefined names, unused imports)
+    "UP",   # pyupgrade (modern Python syntax)
+    "B",    # flake8-bugbear (likely bugs)
+    "SIM",  # flake8-simplify (simpler code)
+    "I",    # isort (import sorting)
+]
+
+# Disable annoying rules
+ignore = [
+    "E501",   # Line too long (we use formatter for this)
+    "B008",   # Function call in argument defaults (common pattern)
+    "SIM105", # Use contextlib.suppress (not always clearer)
+]
+
+[tool.ruff.format]
+# Use double quotes (more modern/common)
+quote-style = "double"
+
+# Keep magic trailing comma behavior
+skip-magic-trailing-comma = false


### PR DESCRIPTION
## Summary
- Add Python linting workflow using ruff
- Modern, non-strict configuration focusing on code quality
- Line length: 120 (not old-school 79)
- Enables: import sorting, bug detection, unused code detection, modern Python syntax
- Disables: strict docstrings, overly strict naming conventions

## Configuration Files
- **pyproject.toml**: Ruff configuration
- **.github/workflows/python_lint.yml**: CI workflow

## Expected CI Status
⚠️ This PR will **fail CI** - that's intentional! The linting rules will be fixed in a follow-up PR.

This PR just adds the linting infrastructure to validate it works correctly.

## Test Plan
- [x] Linting configuration created
- [x] Workflow file added
- [ ] CI runs and shows linting errors (expected to fail)
- [ ] Follow-up PR will fix the code to pass linting

🤖 Generated with [Claude Code](https://claude.com/claude-code)