### PR TITLE
Add pre-commit hooks configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  # Python: Ruff formatter and linter (matches CI)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        name: ruff check
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+        name: ruff format
+
+  # Rust: Format and lint (matches CI)
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        files: \.rs$
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets -- -D warnings
+        language: system
+        files: \.rs$
+        pass_filenames: false
+
+  # General file hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: mixed-line-ending


### PR DESCRIPTION
## Summary
- Add pre-commit configuration to run linting checks before commits
- Matches existing CI checks for consistency

## Configuration
- **Python**: ruff format + ruff check
- **Rust**: cargo fmt + cargo clippy  
- **General**: trailing whitespace, EOF fixer, YAML validation, large file check

## Setup (for team members)
```bash
uv tool install pre-commit
pre-commit install
```

After setup, hooks run automatically on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)