### PR TITLE
feat(cuda): add cuBLAS baseline and GFLOPS/MFU metrics to matmul benchmark

### DIFF
--- a/cuda/matmul/BUILD
+++ b/cuda/matmul/BUILD
@@ -37,6 +37,26 @@ cuda_library(
     includes = [".."],
 )
 
+# cuBLAS baseline kernel
+cuda_library(
+    name = "matmul_cublas",
+    srcs = ["matmul_cublas.cu"],
+    hdrs = [
+        "matmul_cublas.h",
+        "matmul_kernel.h",
+    ],
+    deps = [
+        "//cuda:cuda_utils",
+    ],
+    linkopts = [
+        "-L/usr/local/cuda/lib64",
+        "-lcublas",
+    ],
+    target_compatible_with = ["//constraints:cuda"],
+    includes = [".."],
+    tags = ["cuda", "gpu"],
+)
+
 # ============================================================================
 # Matrix Multiplication Main Binary
 # ============================================================================
@@ -46,9 +66,14 @@ cuda_binary(
     srcs = ["matmul.cpp"],
     deps = [
         ":matmul_naive",
+        ":matmul_cublas",
         ":matmul_kernel_h",
         ":matrix_init",
         "//cuda:cuda_utils",
+    ],
+    linkopts = [
+        "-L/usr/local/cuda/lib64",
+        "-lcublas",
     ],
     target_compatible_with = ["//constraints:cuda"],
     tags = ["cuda", "gpu"],
@@ -116,6 +141,52 @@ cuda_test(
     tags = ["cuda", "gpu"],
 )
 
+# cuBLAS tests for various sizes
+cuda_test(
+    name = "matmul_cublas_256_test",
+    srcs = ["matmul.cpp"],
+    deps = [
+        ":matmul_kernel_h",
+        ":matmul_naive",
+        ":matmul_cublas",
+        ":matrix_init",
+        "//cuda:cuda_utils",
+    ],
+    args = ["--size", "256", "--method", "cublas", "--verify"],
+    target_compatible_with = ["//constraints:cuda"],
+    tags = ["cuda", "gpu"],
+)
+
+cuda_test(
+    name = "matmul_cublas_1024_test",
+    srcs = ["matmul.cpp"],
+    deps = [
+        ":matmul_kernel_h",
+        ":matmul_naive",
+        ":matmul_cublas",
+        ":matrix_init",
+        "//cuda:cuda_utils",
+    ],
+    args = ["--size", "1024", "--method", "cublas", "--verify"],
+    target_compatible_with = ["//constraints:cuda"],
+    tags = ["cuda", "gpu"],
+)
+
+cuda_test(
+    name = "matmul_cublas_2048_test",
+    srcs = ["matmul.cpp"],
+    deps = [
+        ":matmul_kernel_h",
+        ":matmul_naive",
+        ":matmul_cublas",
+        ":matrix_init",
+        "//cuda:cuda_utils",
+    ],
+    args = ["--size", "2048", "--method", "cublas", "--verify"],
+    target_compatible_with = ["//constraints:cuda"],
+    tags = ["cuda", "gpu"],
+)
+
 # ============================================================================
 # Test Suite (run all matmul tests)
 # ============================================================================
@@ -127,5 +198,8 @@ test_suite(
         ":matmul_naive_128_test",
         ":matmul_naive_256_test",
         ":matmul_naive_512_test",
+        ":matmul_cublas_256_test",
+        ":matmul_cublas_1024_test",
+        ":matmul_cublas_2048_test",
     ],
 )

--- a/cuda/matmul/matmul_cublas.cu
+++ b/cuda/matmul/matmul_cublas.cu
@@ -1,0 +1,37 @@
+#include "matmul_cublas.h"
+#include "cuda_utils.h"
+#include <iostream>
+
+// Constructor: Create cuBLAS handle (setup phase, not timed)
+MatmulCublas::MatmulCublas(int N, int blockDim) : N(N) {
+    cublasStatus_t status = cublasCreate(&handle);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        std::cerr << "cuBLAS initialization failed!" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+// Execute: Pure kernel execution (this method is timed in benchmarks)
+void MatmulCublas::execute(const float *d_A, const float *d_B, float *d_C) {
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+
+    // cuBLAS uses column-major ordering, but we have row-major matrices
+    // To compute C = A * B in row-major, we compute C^T = B^T * A^T
+    // which is equivalent to: C = B * A in column-major interpretation
+    cublasSgemm(handle,
+                CUBLAS_OP_N, CUBLAS_OP_N,
+                N, N, N,           // M, N, K dimensions
+                &alpha,
+                d_B, N,            // Matrix B (interpreted as col-major)
+                d_A, N,            // Matrix A (interpreted as col-major)
+                &beta,
+                d_C, N);           // Matrix C (output)
+
+    cudaCheckError(cudaGetLastError());
+}
+
+// Destructor: Clean up cuBLAS handle
+MatmulCublas::~MatmulCublas() {
+    cublasDestroy(handle);
+}

--- a/cuda/matmul/matmul_cublas.h
+++ b/cuda/matmul/matmul_cublas.h
@@ -1,0 +1,18 @@
+#ifndef MATMUL_CUBLAS_H_
+#define MATMUL_CUBLAS_H_
+
+#include "matmul_kernel.h"
+#include <cublas_v2.h>
+
+class MatmulCublas : public MatmulKernel {
+private:
+    cublasHandle_t handle;  // cuBLAS context
+    int N;                  // Matrix dimension
+
+public:
+    MatmulCublas(int N, int blockDim);
+    void execute(const float *d_A, const float *d_B, float *d_C) override;
+    ~MatmulCublas() override;
+};
+
+#endif  // MATMUL_CUBLAS_H_


### PR DESCRIPTION
## Summary
Add cuBLAS kernel as performance baseline and enhance benchmark output with GFLOPS and Model FLOPS Utilization (MFU) metrics for better insights into computational efficiency.

## Changes
- **Add MatmulCublas kernel** wrapping cuBLAS SGEMM (~8-9x faster than naive)
- **Extend benchmark table** to show 3 rows per method:
  - Execution time (ms)
  - GFLOPS/TFLOPS (auto-formatted with G/T suffix)
  - MFU percentage
- **Add GPU detection** with Tensor Core peak FLOPS for accurate MFU:
  - H100: 495 TFLOPS (TF32 Tensor Core)
  - A100: 156 TFLOPS (TF32 Tensor Core)
  - V100: 15.7 TFLOPS (FP32)
  - RTX 30/40 series: FP32 peaks

## Benchmark Results on H100 (1024×1024)
- **Naive**: 2.3 TFLOPS (0.5% MFU)
- **cuBLAS**: 20.1 TFLOPS (4.1% MFU)

## Example Output
```
Method          | 64       | 128      | 256      | 512      | 1K       |
----------------|----------|----------|----------|----------|----------|
naive (time)    |     0.004|     0.006|     0.011|     0.107|     0.923|
       (gflops) | ( 132.2 G)| ( 702.5 G)| (   3.1 T)| (   2.5 T)| (   2.3 T)|
          (mfu) | (   0.0%)| (   0.1%)| (   0.6%)| (   0.5%)| (   0.5%)|
cublas (time)   |     0.004|     0.005|     0.009|     0.015|     0.107|
       (gflops) | ( 124.8 G)| ( 763.2 G)| (   3.9 T)| (  17.9 T)| (  20.1 T)|
          (mfu) | (   0.0%)| (   0.2%)| (   0.8%)| (   3.6%)| (   4.1%)|
```

## Test Plan
- [x] Build passes: `bazel build //cuda/matmul:matmul --platforms=//platforms:cuda`
- [x] Verification passes for both kernels at all sizes (64, 128, 256, 512, 1024)
- [x] cuBLAS achieves expected performance (~20 TFLOPS on H100)
- [x] MFU metrics show realistic values with Tensor Core peaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)