### PR TITLE
feat(coverage): add README with Codecov badge and coverage config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Cyborg Lambda
+
+A monorepo containing CUDA kernels, AI/LLM implementations, and visual processing applications.
+
+[![Codecov](https://codecov.io/gh/ziliangpeng/cyborg/branch/main/graph/badge.svg)](https://codecov.io/gh/ziliangpeng/cyborg)
+
+## Structure
+
+- `ai/` - AI and LLM implementations
+- `apps/` - Applications (halftone, cybervision, tokenizer_viz, etc.)
+- `cuda/` - CUDA kernel implementations
+- `visual/` - Visual processing utilities
+- `experimental/` - Experimental code
+
+## Building
+
+This project uses [Bazel](https://bazel.build) as its build system.
+
+```bash
+# Run all tests
+bazel test //...
+
+# Build all targets
+bazel build //...
+
+# Run tests with coverage
+bazel coverage --config=ci //...
+```
+
+## CI/CD
+
+- Bazel tests run on every push to main and PRs
+- Coverage is uploaded to Codecov automatically
+- Playwright tests run for cybervision app
+
+## License
+
+MIT

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+codecov:
+  require_ci_to_pass: false
+
+comment:
+  layout: "header, diff, flags, components"
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%


### PR DESCRIPTION
## Summary
- Add README.md with project overview and Codecov coverage badge
- Add codecov.yml with basic coverage configuration

The Codecov badge will display coverage percentage for code with Bazel test targets.