### PR TITLE
feat: add client-side video selection with file picker and drag-drop

### DIFF
--- a/apps/cybervision-player/webroot/index.html
+++ b/apps/cybervision-player/webroot/index.html
@@ -18,16 +18,12 @@
         <!-- Left panel: Video -->
         <section class="video-panel panel">
           <div class="video-input-section">
-            <label for="video-path">Video File:</label>
-            <input
-              type="text"
-              id="video-path"
-              class="select"
-              value="/Users/victor.peng/Downloads/IMG_1985.MOV"
-              placeholder="/Users/username/Movies/video.mp4"
-              autocomplete="off"
-            />
-            <button id="load-video-btn" class="button">Load</button>
+            <input type="file" id="videoFile" accept="video/*" style="display: none;">
+            <div id="dropZone" class="drop-zone">
+              <button id="chooseFileBtn" class="button">Choose Video File</button>
+              <span class="drop-hint">or drag & drop</span>
+            </div>
+            <div id="currentFile" class="current-file"></div>
           </div>
           <div class="video-container">
             <canvas id="video-canvas" class="video-output"></canvas>

--- a/apps/cybervision-player/webroot/static/style.css
+++ b/apps/cybervision-player/webroot/static/style.css
@@ -66,3 +66,32 @@
 .file-input::file-selector-button:hover {
   background: rgba(96, 165, 250, 0.28);
 }
+
+/* Drop zone styling */
+.drop-zone {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px;
+  border: 2px dashed var(--border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+  transition: all 0.2s ease;
+}
+
+.drop-zone.drag-over {
+  border-color: var(--accent);
+  background: rgba(96, 165, 250, 0.1);
+}
+
+.drop-hint {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.current-file {
+  margin-top: 8px;
+  font-size: 14px;
+  color: var(--text);
+  word-break: break-all;
+}


### PR DESCRIPTION
## Summary

- Replace server-side video path input with native file picker and drag-drop zone
- Add `loadLocalVideo()` method that creates blob URLs for direct browser playback
- Implement proper blob URL cleanup to prevent memory leaks when switching videos
- Add CSS styling for drop zone with drag-over visual feedback

## Test plan

- [ ] Click "Choose Video File" button and select a local video file
- [ ] Verify video loads and plays with shader effects applied
- [ ] Drag and drop a video file onto the drop zone
- [ ] Verify filename displays correctly after file selection
- [ ] Switch between multiple videos and verify no memory leaks (blob URLs revoked)
- [ ] Verify drag-over visual feedback (border highlight) when dragging files

🤖 Generated with [Claude Code](https://claude.com/claude-code)