### PR TITLE
test(cybervision): expand player unit coverage

### DIFF
--- a/apps/cybervision/tests/unit/__mocks__/webgpu-renderer.js
+++ b/apps/cybervision/tests/unit/__mocks__/webgpu-renderer.js
@@ -1,4 +1,24 @@
 // Mock WebGPU renderer for testing
+export async function initGPU() {
+  return {
+    renderPassthrough: () => {},
+    renderHalftone: () => {},
+    renderMosaic: () => {},
+    renderClustering: () => {},
+    renderEdges: () => {},
+    renderChromatic: () => {},
+    renderGlitch: () => {},
+    renderThermal: () => {},
+    renderKaleidoscope: () => {},
+    renderPixelSort: () => {},
+    renderSegmentation: () => {},
+    updateBackgroundImage: () => {},
+    updateDotSize: () => {},
+    setupPipeline: async () => {},
+    cleanup: () => {}
+  };
+}
+
 export class WebGPURenderer {
   constructor() {}
   async init() {}

--- a/apps/cybervision/webroot/static/app.js
+++ b/apps/cybervision/webroot/static/app.js
@@ -949,6 +949,40 @@ class CyberVision {
     this.setStatus("Playback ended", this.playerStatusEl);
   }
 
+  onVideoError(event) {
+    const errorCode = event?.target?.error?.code;
+    let message = "Video error: Unable to load the video.";
+
+    switch (errorCode) {
+      case 1:
+        message = "Video error: Playback was aborted.";
+        break;
+      case 2:
+        message = "Video error: Network error while loading.";
+        break;
+      case 3:
+        message = "Video error: Media decoding failed.";
+        break;
+      case 4:
+        message = "Video error: Format not supported.";
+        break;
+      default:
+        break;
+    }
+
+    if (this.videoAnimationFrame) {
+      cancelAnimationFrame(this.videoAnimationFrame);
+      this.videoAnimationFrame = null;
+    }
+
+    this.isVideoPlaying = false;
+    this.isVideoLoaded = false;
+    this.playPauseBtn.textContent = "Play";
+    this.playPauseBtn.disabled = true;
+    this.seekSlider.disabled = true;
+    this.setStatus(message, this.playerStatusEl);
+  }
+
   startVideoRenderLoop() {
     const render = () => {
       if (!this.isVideoPlaying || this.activeInputSource !== 'video-file') return;


### PR DESCRIPTION
## Summary
- add unit coverage for playback/render loops, renderer switching, and input source flows
- cover segmentation model load, background upload, and error handling
- add video error handling to avoid missing handler crashes

## Testing
- bazel --output_user_root=/tmp/cyborg-omega-bazel-user test //apps/cybervision:unit_tests