### PR TITLE
feat(docker): add Claude Code sandbox container

### DIFF
--- a/docker/claude-sandbox/Dockerfile
+++ b/docker/claude-sandbox/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-slim
+
+# Install Claude Code globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Install common dev tools and gh CLI
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    jq \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Use the existing node user (UID/GID 1000)
+# This matches most macOS users' default UID
+USER node
+WORKDIR /workspace
+
+# Entry point runs claude with dangerous skip permissions
+ENTRYPOINT ["claude", "--dangerously-skip-permissions"]

--- a/docker/claude-sandbox/docker-compose.yml
+++ b/docker/claude-sandbox/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  claude:
+    build:
+      context: .
+    volumes:
+      # Mount current repo
+      - ../../:/workspace
+      # Mount container home directory (for .config, etc)
+      - ~/.claude/sandboxed-home:/home/node
+      # Mount Claude config (memory, settings, history, skills)
+      - ~/.claude:/home/node/.claude
+      # Mount git config for commits
+      - ~/.gitconfig:/home/node/.gitconfig:ro
+      - ~/.ssh:/home/node/.ssh:ro
+    stdin_open: true
+    tty: true

--- a/docker/claude-sandbox/run.sh
+++ b/docker/claude-sandbox/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Helper script to run the Claude sandbox
+
+docker compose run --rm claude "$@"

--- a/scripts/claude-sandbox.sh
+++ b/scripts/claude-sandbox.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Run Claude Code in a sandboxed Docker container
+#
+# Usage:
+#   ./scripts/claude-sandbox.sh              # Interactive Claude session
+#   ./scripts/claude-sandbox.sh --model opus # Pass extra args to Claude
+#   ./scripts/claude-sandbox.sh -p "query"   # Non-interactive mode
+#
+# First time setup:
+#   1. Run 'claude setup-token' on your host machine
+#   2. Export the token: export CLAUDE_SETUP_TOKEN=<your-token>
+#   3. Or add to your shell rc file for persistence
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCKER_DIR="$REPO_ROOT/docker/claude-sandbox"
+
+# Build and run
+cd "$DOCKER_DIR"
+docker compose build --quiet
+docker compose run --rm claude "$@"


### PR DESCRIPTION
## Summary

- Adds Docker setup to run Claude Code with `--dangerously-skip-permissions` in a sandboxed container
- Mounts the repo at `/workspace` and uses `~/.claude/sandboxed-home` for persistent config/auth
- Includes helper script at `scripts/claude-sandbox.sh` for easy invocation

## Test plan

- [x] Build image: `cd docker/claude-sandbox && docker compose build`
- [x] Run: `./scripts/claude-sandbox.sh --version`
- [ ] Interactive session with auth configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)