### PR TITLE
feat(batch_softmax): add autotuning and online multi-warp kernel

### DIFF
--- a/cuda/batch_softmax/BUILD.bazel
+++ b/cuda/batch_softmax/BUILD.bazel
@@ -115,6 +115,45 @@ cuda_library(
     includes = [".."],
 )
 
+# Online multi-warp implementation (single-pass statistics + multi-warp + vectorization)
+cuda_library(
+    name = "batch_softmax_online_multi_warp",
+    srcs = ["batch_softmax_online_multi_warp.cu"],
+    hdrs = [
+        "batch_softmax_online_multi_warp.h",
+        "batch_softmax_kernel.h",
+    ],
+    deps = [
+        "//cuda:cuda_utils",
+    ],
+    target_compatible_with = ["//constraints:cuda"],
+    includes = [".."],
+)
+
+# Autotuner for runtime configuration optimization
+cuda_library(
+    name = "batch_softmax_autotuner",
+    srcs = ["batch_softmax_autotuner.cu"],
+    hdrs = [
+        "batch_softmax_autotuner.h",
+        "batch_softmax_kernel.h",
+    ],
+    deps = [
+        ":batch_softmax_naive",
+        ":batch_softmax_multi_warp",
+        ":batch_softmax_cub",
+        ":batch_softmax_cudnn",
+        ":batch_softmax_online_multi_warp",
+        "//cuda:cuda_utils",
+    ],
+    linkopts = [
+        "-L/lib/x86_64-linux-gnu",
+        "-lcudnn",
+    ],
+    target_compatible_with = ["//constraints:cuda"],
+    includes = [".."],
+)
+
 # ============================================================================
 # Batch Softmax Main Binary (Performance Benchmark)
 # ============================================================================
@@ -130,6 +169,8 @@ cuda_binary(
         ":batch_softmax_cub",
         ":batch_softmax_cudnn",
         ":batch_softmax_hybrid",
+        ":batch_softmax_online_multi_warp",
+        ":batch_softmax_autotuner",
         "//cuda:cuda_utils",
         "//cuda:vector_init",
         "//cuda/common:benchmark_utils",

--- a/cuda/batch_softmax/batch_softmax_autotuner.cu
+++ b/cuda/batch_softmax/batch_softmax_autotuner.cu
@@ -1,0 +1,176 @@
+#include "batch_softmax_autotuner.h"
+#include "batch_softmax_naive.h"
+#include "batch_softmax_multi_warp.h"
+#include "batch_softmax_cub.h"
+#include "batch_softmax_cudnn.h"
+#include "batch_softmax_online_multi_warp.h"
+#include "cuda_utils.h"
+#include <cuda_runtime.h>
+#include <stdio.h>
+#include <vector>
+#include <float.h>
+
+// ============================================================================
+// BATCH SOFTMAX AUTOTUNER IMPLEMENTATION
+// ============================================================================
+//
+// General autotuning strategy:
+// 1. Try each config value in the provided list
+// 2. For each config, run warmup iterations to get GPU into steady state
+// 3. Time multiple iterations and compute average
+// 4. Track the fastest config
+// 5. Return the best config and its timing
+//
+// ============================================================================
+
+// Generic autotuning helper function
+// Takes a vector of configs and a factory function that creates kernels
+template<typename KernelFactory>
+AutotuneResult autotune_generic(
+    const std::vector<int>& configs,
+    KernelFactory factory,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters,
+    int timed_iters
+) {
+    AutotuneResult result;
+    result.best_time_ms = FLT_MAX;
+
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    for (int config : configs) {
+        BatchSoftmaxKernel* kernel = nullptr;
+        try {
+            kernel = factory(config);
+        } catch (...) {
+            // Skip configs that fail to instantiate
+            continue;
+        }
+
+        if (!kernel) continue;
+
+        // Warmup runs
+        for (int i = 0; i < warmup_iters; i++) {
+            kernel->execute(d_input, d_output);
+        }
+        cudaDeviceSynchronize();
+
+        // Timed runs
+        cudaEventRecord(start);
+        for (int i = 0; i < timed_iters; i++) {
+            kernel->execute(d_input, d_output);
+        }
+        cudaEventRecord(stop);
+        cudaEventSynchronize(stop);
+
+        float total_ms = 0.0f;
+        cudaEventElapsedTime(&total_ms, start, stop);
+        float avg_ms = total_ms / timed_iters;
+
+        if (avg_ms < result.best_time_ms) {
+            result.best_time_ms = avg_ms;
+            result.best_config = config;
+        }
+
+        delete kernel;
+    }
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+
+    return result;
+}
+
+// Autotune the naive batch softmax kernel
+AutotuneResult autotune_naive(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters,
+    int timed_iters
+) {
+    std::vector<int> configs = {64, 128, 256, 512};
+
+    auto factory = [batch_size, dim](int threadsPerBlock) -> BatchSoftmaxKernel* {
+        return new NaiveBatchSoftmax(batch_size, dim, threadsPerBlock);
+    };
+
+    return autotune_generic(configs, factory, d_input, d_output, warmup_iters, timed_iters);
+}
+
+// Autotune the multi_warp batch softmax kernel
+AutotuneResult autotune_multi_warp(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters,
+    int timed_iters
+) {
+    std::vector<int> configs = {4, 8, 16};
+
+    auto factory = [batch_size, dim](int num_warps) -> BatchSoftmaxKernel* {
+        return new MultiWarpBatchSoftmax(batch_size, dim, num_warps);
+    };
+
+    return autotune_generic(configs, factory, d_input, d_output, warmup_iters, timed_iters);
+}
+
+// Autotune the CUB batch softmax kernel
+AutotuneResult autotune_cub(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters,
+    int timed_iters
+) {
+    std::vector<int> configs = {128, 256, 512};
+
+    auto factory = [batch_size, dim](int threadsPerBlock) -> BatchSoftmaxKernel* {
+        return new CubBatchSoftmax(batch_size, dim, threadsPerBlock);
+    };
+
+    return autotune_generic(configs, factory, d_input, d_output, warmup_iters, timed_iters);
+}
+
+// Autotune the cuDNN batch softmax kernel
+AutotuneResult autotune_cudnn(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters,
+    int timed_iters
+) {
+    // 0 = CUDNN_SOFTMAX_FAST, 1 = CUDNN_SOFTMAX_ACCURATE
+    std::vector<int> configs = {0, 1};
+
+    auto factory = [batch_size, dim](int algorithm) -> BatchSoftmaxKernel* {
+        return new CudnnBatchSoftmax(batch_size, dim, algorithm);
+    };
+
+    return autotune_generic(configs, factory, d_input, d_output, warmup_iters, timed_iters);
+}
+
+// Autotune the online multi-warp batch softmax kernel
+AutotuneResult autotune_online_multi_warp(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters,
+    int timed_iters
+) {
+    std::vector<int> configs = {4, 8, 16};
+
+    auto factory = [batch_size, dim](int num_warps) -> BatchSoftmaxKernel* {
+        return new OnlineMultiWarpBatchSoftmax(batch_size, dim, num_warps);
+    };
+
+    return autotune_generic(configs, factory, d_input, d_output, warmup_iters, timed_iters);
+}

--- a/cuda/batch_softmax/batch_softmax_autotuner.h
+++ b/cuda/batch_softmax/batch_softmax_autotuner.h
@@ -1,0 +1,97 @@
+#ifndef BATCH_SOFTMAX_AUTOTUNER_H
+#define BATCH_SOFTMAX_AUTOTUNER_H
+
+#include "batch_softmax_kernel.h"
+#include <vector>
+
+// ============================================================================
+// BATCH SOFTMAX AUTOTUNER
+// ============================================================================
+//
+// This module provides runtime autotuning for batch softmax kernels.
+// For kernels with tunable hyperparameters, the autotuner tries all
+// supported configurations and returns the best one for a given shape.
+//
+// TUNABLE KERNELS:
+// ----------------
+// 1. naive:      threadsPerBlock (64, 128, 256, 512)
+// 2. multi_warp: num_warps (4, 8, 16)
+// 3. cub:        threadsPerBlock (128, 256, 512)
+//
+// AUTOTUNING PROCESS:
+// -------------------
+// For each config:
+// 1. Create kernel with that config
+// 2. Run warmup iterations to stabilize GPU state
+// 3. Run timed iterations and measure elapsed time
+// 4. Track the fastest config
+//
+// Returns the best config value (e.g., best threadsPerBlock or num_warps)
+//
+// ============================================================================
+
+// Autotune result containing best config and timing info
+struct AutotuneResult {
+    int best_config;      // The config value that performed best
+    float best_time_ms;   // Time in milliseconds for best config
+
+    AutotuneResult() : best_config(0), best_time_ms(0.0f) {}
+    AutotuneResult(int config, float time) : best_config(config), best_time_ms(time) {}
+};
+
+// Autotune the naive batch softmax kernel
+// Returns the best threadsPerBlock value (64, 128, 256, or 512)
+AutotuneResult autotune_naive(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters = 3,
+    int timed_iters = 10
+);
+
+// Autotune the multi_warp batch softmax kernel
+// Returns the best num_warps value (4, 8, or 16)
+AutotuneResult autotune_multi_warp(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters = 3,
+    int timed_iters = 10
+);
+
+// Autotune the CUB batch softmax kernel
+// Returns the best threadsPerBlock value (128, 256, or 512)
+AutotuneResult autotune_cub(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters = 3,
+    int timed_iters = 10
+);
+
+// Autotune the cuDNN batch softmax kernel
+// Returns the best algorithm: 0 = FAST, 1 = ACCURATE
+AutotuneResult autotune_cudnn(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters = 3,
+    int timed_iters = 10
+);
+
+// Autotune the online multi-warp batch softmax kernel
+// Returns the best num_warps value (4, 8, or 16)
+AutotuneResult autotune_online_multi_warp(
+    int batch_size,
+    int dim,
+    const float* d_input,
+    float* d_output,
+    int warmup_iters = 3,
+    int timed_iters = 10
+);
+
+#endif  // BATCH_SOFTMAX_AUTOTUNER_H

--- a/cuda/batch_softmax/batch_softmax_cudnn.cu
+++ b/cuda/batch_softmax/batch_softmax_cudnn.cu
@@ -43,10 +43,10 @@
 // CLASS-BASED IMPLEMENTATION
 // ============================================================================
 
-CudnnBatchSoftmax::CudnnBatchSoftmax(int batch_size, int dim, int threadsPerBlock)
+CudnnBatchSoftmax::CudnnBatchSoftmax(int batch_size, int dim, int algorithm)
     : batch_size(batch_size), dim(dim) {
-    // threadsPerBlock is unused for cuDNN
-    (void)threadsPerBlock;
+    // Set algorithm: 0 = FAST, 1 = ACCURATE (default)
+    algo = (algorithm == 0) ? CUDNN_SOFTMAX_FAST : CUDNN_SOFTMAX_ACCURATE;
 
     // Create cuDNN handle
     cudnnCheckError(cudnnCreate(&cudnn));
@@ -72,7 +72,7 @@ void CudnnBatchSoftmax::execute(const float *d_input, float *d_output) {
 
     cudnnCheckError(cudnnSoftmaxForward(
         cudnn,
-        CUDNN_SOFTMAX_ACCURATE,      // Algorithm: numerically stable
+        algo,                        // Algorithm: FAST or ACCURATE
         CUDNN_SOFTMAX_MODE_CHANNEL,  // Mode: softmax across C (dim) for each N
         &alpha,
         tensor_desc,

--- a/cuda/batch_softmax/batch_softmax_cudnn.h
+++ b/cuda/batch_softmax/batch_softmax_cudnn.h
@@ -20,21 +20,23 @@
 // - CUDNN_SOFTMAX_MODE_CHANNEL computes softmax across C dimension (dim)
 // - Each row of batch_size rows gets independent softmax
 //
-// cuDNN Softmax Algorithms:
-// - CUDNN_SOFTMAX_FAST: May use approximations, very fast
-// - CUDNN_SOFTMAX_ACCURATE: Numerically stable (uses log-sum-exp trick)
-// - CUDNN_SOFTMAX_LOG: Computes log(softmax(x)) directly
+// TUNABLE PARAMETER:
+// - algorithm: CUDNN_SOFTMAX_FAST (0) or CUDNN_SOFTMAX_ACCURATE (1)
+//   - FAST: May use approximations, potentially faster
+//   - ACCURATE: Numerically stable (uses log-sum-exp trick)
 //
-// We use CUDNN_SOFTMAX_ACCURATE + CUDNN_SOFTMAX_MODE_CHANNEL for batched softmax.
+// We use CUDNN_SOFTMAX_MODE_CHANNEL for batched softmax.
 class CudnnBatchSoftmax : public BatchSoftmaxKernel {
 public:
-    CudnnBatchSoftmax(int batch_size, int dim, int threadsPerBlock);
+    // algorithm: 0 = CUDNN_SOFTMAX_FAST, 1 = CUDNN_SOFTMAX_ACCURATE (default)
+    CudnnBatchSoftmax(int batch_size, int dim, int algorithm = 1);
     void execute(const float *d_input, float *d_output) override;
     ~CudnnBatchSoftmax() override;
 
 private:
     cudnnHandle_t cudnn;
     cudnnTensorDescriptor_t tensor_desc;
+    cudnnSoftmaxAlgorithm_t algo;
     int batch_size;
     int dim;
 };

--- a/cuda/batch_softmax/batch_softmax_hybrid.cu
+++ b/cuda/batch_softmax/batch_softmax_hybrid.cu
@@ -42,7 +42,8 @@ HybridBatchSoftmax::HybridBatchSoftmax(int batch_size, int dim, int threadsPerBl
     if (dim <= 64) {
         kernel_impl = std::make_unique<WarpBatchSoftmax>(batch_size, dim, 32);
     } else {
-        kernel_impl = std::make_unique<MultiWarpBatchSoftmax>(batch_size, dim, 256);
+        // Use 8 warps (256 threads) as default for multi_warp kernel
+        kernel_impl = std::make_unique<MultiWarpBatchSoftmax>(batch_size, dim, 8);
     }
 }
 

--- a/cuda/batch_softmax/batch_softmax_multi_warp.h
+++ b/cuda/batch_softmax/batch_softmax_multi_warp.h
@@ -8,16 +8,22 @@
 // Optimized for large dimensions (4K+) using multiple warps per block and
 // float4 vectorized memory access for improved bandwidth utilization.
 //
-// Architecture: Multiple warps (typically 8) per row, one block per row
+// Architecture: Multiple warps (configurable: 4, 8, or 16) per row, one block per row
 // - Each warp computes partial (max, sum) via warp shuffles
-// - Cross-warp reduction via shared memory (only 8 values for 256 threads)
+// - Cross-warp reduction via shared memory (only num_warps values)
 // - Vectorized loads (float4) when dim is divisible by 4
 //
 // Key optimizations:
-// 1. Multiple warps: 256 threads vs 32, better utilization for large dims
+// 1. Multiple warps: configurable threads vs 32, better utilization for large dims
 // 2. Hybrid reduction: warp shuffles first, minimal shared memory second
 // 3. Vectorized loads: 4x memory bandwidth improvement
 // 4. Minimized synchronization: only 2 __syncthreads() per phase
+//
+// TUNABLE PARAMETER:
+// - num_warps: Number of warps per block (4, 8, or 16)
+//   - 4 warps = 128 threads: lower overhead, good for medium dims
+//   - 8 warps = 256 threads: balanced (default)
+//   - 16 warps = 512 threads: higher parallelism, good for very large dims
 //
 // Performance characteristics:
 // - Best for dim >= 1024 where vectorization benefits outweigh overhead
@@ -25,14 +31,16 @@
 // - Vectorized path requires dim % 4 == 0
 class MultiWarpBatchSoftmax : public BatchSoftmaxKernel {
 public:
-    MultiWarpBatchSoftmax(int batch_size, int dim, int threadsPerBlock);
+    // Constructor takes num_warps (4, 8, or 16) which determines threads per block
+    // threadsPerBlock parameter is interpreted as num_warps for this kernel
+    MultiWarpBatchSoftmax(int batch_size, int dim, int num_warps);
     void execute(const float *d_input, float *d_output) override;
     ~MultiWarpBatchSoftmax() = default;
 
 private:
     int batch_size;
     int dim;
-    int threadsPerBlock;
+    int num_warps;        // Number of warps per block (4, 8, or 16)
     bool use_vectorized;  // True if dim % 4 == 0
 };
 

--- a/cuda/batch_softmax/batch_softmax_online_multi_warp.cu
+++ b/cuda/batch_softmax/batch_softmax_online_multi_warp.cu
@@ -1,0 +1,315 @@
+#include "batch_softmax_online_multi_warp.h"
+#include "cuda_utils.h"
+#include <cuda_runtime.h>
+#include <math.h>
+#include <stdexcept>
+
+// ============================================================================
+// ONLINE MULTI-WARP BATCH SOFTMAX WITH VECTORIZED LOADS
+// ============================================================================
+//
+// This kernel combines the online softmax algorithm with multi-warp parallelism
+// and vectorized memory access for optimal performance on large dimensions.
+//
+// ONLINE SOFTMAX (Milakov & Gimelshein, 2018):
+// --------------------------------------------
+// Instead of separate max and sum passes, we compute both in a single pass:
+//   For each element x:
+//     old_max = max
+//     max = fmaxf(max, x)
+//     sum = sum * exp(old_max - max) + exp(x - max)
+//
+// This saves one full memory pass compared to the traditional approach.
+//
+// HYBRID REDUCTION FOR (MAX, SUM) PAIRS:
+// --------------------------------------
+// Phase 1: Each thread computes local (max, sum) via online updates
+// Phase 2: Warp-level reduction using shuffles (merge (max,sum) pairs)
+// Phase 3: Cross-warp reduction via shared memory
+// Phase 4: Normalize output
+//
+// MERGING FORMULA:
+// ----------------
+// merged_max = max(max1, max2)
+// merged_sum = sum1 * exp(max1 - merged_max) + sum2 * exp(max2 - merged_max)
+//
+// NaN PROTECTION:
+// ---------------
+// When max = -INFINITY, exp(-INFINITY - (-INFINITY)) = NaN
+// Solution: Check for -INFINITY and use 0.0 for sum contribution
+//
+// ============================================================================
+
+#define FULL_MASK 0xffffffff
+
+// Helper: Merge two (max, sum) pairs using online softmax formula
+__device__ __forceinline__ void mergeOnlinePair(
+    float &max1, float &sum1,
+    float max2, float sum2
+) {
+    float merged_max = fmaxf(max1, max2);
+
+    // NaN protection: avoid exp(-INFINITY - (-INFINITY))
+    float contrib1 = isinf(max1) ? 0.0f : sum1 * expf(max1 - merged_max);
+    float contrib2 = isinf(max2) ? 0.0f : sum2 * expf(max2 - merged_max);
+
+    max1 = merged_max;
+    sum1 = contrib1 + contrib2;
+}
+
+// Helper: Warp-level reduction of (max, sum) pairs using shuffles
+__device__ __forceinline__ void warpReduceOnlinePair(float &thread_max, float &thread_sum) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        float other_max = __shfl_down_sync(FULL_MASK, thread_max, offset);
+        float other_sum = __shfl_down_sync(FULL_MASK, thread_sum, offset);
+        mergeOnlinePair(thread_max, thread_sum, other_max, other_sum);
+    }
+}
+
+// Scalar kernel for non-vectorizable dimensions
+template<int WARPS_PER_BLOCK>
+__global__ void batch_softmax_online_multi_warp_scalar_kernel(
+    const float *input,
+    float *output,
+    int batch_size,
+    int dim
+) {
+    constexpr int BLOCK_SIZE = WARPS_PER_BLOCK * 32;
+
+    int row = blockIdx.x;
+    if (row >= batch_size) return;
+
+    const float *row_input = input + row * dim;
+    float *row_output = output + row * dim;
+
+    int tid = threadIdx.x;
+    int warp_id = tid / 32;
+    int lane_id = tid % 32;
+
+    // Shared memory for cross-warp reduction of (max, sum) pairs
+    __shared__ float warp_maxes[WARPS_PER_BLOCK];
+    __shared__ float warp_sums[WARPS_PER_BLOCK];
+
+    // ========================================================================
+    // PHASE 1: Online computation of (max, sum) - single pass over input
+    // ========================================================================
+
+    float thread_max = -INFINITY;
+    float thread_sum = 0.0f;
+
+    for (int i = tid; i < dim; i += BLOCK_SIZE) {
+        float x = row_input[i];
+
+        // Online update: merge new element into running (max, sum)
+        float old_max = thread_max;
+        thread_max = fmaxf(thread_max, x);
+
+        // Update sum with correction factor for new max
+        thread_sum = (isinf(old_max) ? 0.0f : thread_sum * expf(old_max - thread_max))
+                   + expf(x - thread_max);
+    }
+
+    // ========================================================================
+    // PHASE 2: Warp-level reduction of (max, sum) pairs
+    // ========================================================================
+
+    warpReduceOnlinePair(thread_max, thread_sum);
+
+    // Lane 0 of each warp writes to shared memory
+    if (lane_id == 0) {
+        warp_maxes[warp_id] = thread_max;
+        warp_sums[warp_id] = thread_sum;
+    }
+    __syncthreads();
+
+    // ========================================================================
+    // PHASE 3: Cross-warp reduction (first warp reduces all warp results)
+    // ========================================================================
+
+    __shared__ float row_max_shared;
+    __shared__ float row_sum_shared;
+
+    if (warp_id == 0) {
+        // Load warp results (or identity values for inactive lanes)
+        float val_max = (lane_id < WARPS_PER_BLOCK) ? warp_maxes[lane_id] : -INFINITY;
+        float val_sum = (lane_id < WARPS_PER_BLOCK) ? warp_sums[lane_id] : 0.0f;
+
+        // Reduce across the first warp
+        warpReduceOnlinePair(val_max, val_sum);
+
+        if (lane_id == 0) {
+            row_max_shared = val_max;
+            row_sum_shared = val_sum;
+        }
+    }
+    __syncthreads();
+
+    float row_max = row_max_shared;
+    float row_sum = row_sum_shared;
+
+    // ========================================================================
+    // PHASE 4: Normalize output
+    // ========================================================================
+
+    float inv_sum = 1.0f / row_sum;
+    for (int i = tid; i < dim; i += BLOCK_SIZE) {
+        row_output[i] = expf(row_input[i] - row_max) * inv_sum;
+    }
+}
+
+// Vectorized kernel using float4 loads
+template<int WARPS_PER_BLOCK>
+__global__ void batch_softmax_online_multi_warp_vec4_kernel(
+    const float *input,
+    float *output,
+    int batch_size,
+    int dim
+) {
+    constexpr int BLOCK_SIZE = WARPS_PER_BLOCK * 32;
+
+    int row = blockIdx.x;
+    if (row >= batch_size) return;
+
+    const float *row_input = input + row * dim;
+    float *row_output = output + row * dim;
+
+    const float4 *row_input4 = reinterpret_cast<const float4*>(row_input);
+    float4 *row_output4 = reinterpret_cast<float4*>(row_output);
+    int dim4 = dim / 4;
+
+    int tid = threadIdx.x;
+    int warp_id = tid / 32;
+    int lane_id = tid % 32;
+
+    __shared__ float warp_maxes[WARPS_PER_BLOCK];
+    __shared__ float warp_sums[WARPS_PER_BLOCK];
+
+    // ========================================================================
+    // PHASE 1: Online computation with vectorized loads
+    // ========================================================================
+
+    float thread_max = -INFINITY;
+    float thread_sum = 0.0f;
+
+    for (int i = tid; i < dim4; i += BLOCK_SIZE) {
+        float4 vals = row_input4[i];
+
+        // Process 4 elements with online updates
+        // Element x
+        float old_max = thread_max;
+        thread_max = fmaxf(thread_max, vals.x);
+        thread_sum = (isinf(old_max) ? 0.0f : thread_sum * expf(old_max - thread_max))
+                   + expf(vals.x - thread_max);
+
+        // Element y
+        old_max = thread_max;
+        thread_max = fmaxf(thread_max, vals.y);
+        thread_sum = (isinf(old_max) ? 0.0f : thread_sum * expf(old_max - thread_max))
+                   + expf(vals.y - thread_max);
+
+        // Element z
+        old_max = thread_max;
+        thread_max = fmaxf(thread_max, vals.z);
+        thread_sum = (isinf(old_max) ? 0.0f : thread_sum * expf(old_max - thread_max))
+                   + expf(vals.z - thread_max);
+
+        // Element w
+        old_max = thread_max;
+        thread_max = fmaxf(thread_max, vals.w);
+        thread_sum = (isinf(old_max) ? 0.0f : thread_sum * expf(old_max - thread_max))
+                   + expf(vals.w - thread_max);
+    }
+
+    // ========================================================================
+    // PHASE 2: Warp-level reduction
+    // ========================================================================
+
+    warpReduceOnlinePair(thread_max, thread_sum);
+
+    if (lane_id == 0) {
+        warp_maxes[warp_id] = thread_max;
+        warp_sums[warp_id] = thread_sum;
+    }
+    __syncthreads();
+
+    // ========================================================================
+    // PHASE 3: Cross-warp reduction
+    // ========================================================================
+
+    __shared__ float row_max_shared;
+    __shared__ float row_sum_shared;
+
+    if (warp_id == 0) {
+        float val_max = (lane_id < WARPS_PER_BLOCK) ? warp_maxes[lane_id] : -INFINITY;
+        float val_sum = (lane_id < WARPS_PER_BLOCK) ? warp_sums[lane_id] : 0.0f;
+
+        warpReduceOnlinePair(val_max, val_sum);
+
+        if (lane_id == 0) {
+            row_max_shared = val_max;
+            row_sum_shared = val_sum;
+        }
+    }
+    __syncthreads();
+
+    float row_max = row_max_shared;
+    float row_sum = row_sum_shared;
+
+    // ========================================================================
+    // PHASE 4: Normalize output with vectorized stores
+    // ========================================================================
+
+    float inv_sum = 1.0f / row_sum;
+    for (int i = tid; i < dim4; i += BLOCK_SIZE) {
+        float4 vals = row_input4[i];
+        float4 out;
+        out.x = expf(vals.x - row_max) * inv_sum;
+        out.y = expf(vals.y - row_max) * inv_sum;
+        out.z = expf(vals.z - row_max) * inv_sum;
+        out.w = expf(vals.w - row_max) * inv_sum;
+        row_output4[i] = out;
+    }
+}
+
+// ============================================================================
+// CLASS-BASED IMPLEMENTATION
+// ============================================================================
+
+OnlineMultiWarpBatchSoftmax::OnlineMultiWarpBatchSoftmax(int batch_size, int dim, int num_warps)
+    : batch_size(batch_size), dim(dim), num_warps(num_warps) {
+    if (num_warps != 4 && num_warps != 8 && num_warps != 16) {
+        fprintf(stderr, "Error: online_multi_warp only supports 4, 8, or 16 warps.\n");
+        fprintf(stderr, "       Requested warps: %d\n", num_warps);
+        throw std::invalid_argument("Unsupported num_warps for online_multi_warp");
+    }
+
+    use_vectorized = (dim % 4 == 0);
+}
+
+void OnlineMultiWarpBatchSoftmax::execute(const float *d_input, float *d_output) {
+    if (use_vectorized) {
+        if (num_warps == 4) {
+            batch_softmax_online_multi_warp_vec4_kernel<4><<<batch_size, 4 * 32>>>(
+                d_input, d_output, batch_size, dim);
+        } else if (num_warps == 8) {
+            batch_softmax_online_multi_warp_vec4_kernel<8><<<batch_size, 8 * 32>>>(
+                d_input, d_output, batch_size, dim);
+        } else if (num_warps == 16) {
+            batch_softmax_online_multi_warp_vec4_kernel<16><<<batch_size, 16 * 32>>>(
+                d_input, d_output, batch_size, dim);
+        }
+    } else {
+        if (num_warps == 4) {
+            batch_softmax_online_multi_warp_scalar_kernel<4><<<batch_size, 4 * 32>>>(
+                d_input, d_output, batch_size, dim);
+        } else if (num_warps == 8) {
+            batch_softmax_online_multi_warp_scalar_kernel<8><<<batch_size, 8 * 32>>>(
+                d_input, d_output, batch_size, dim);
+        } else if (num_warps == 16) {
+            batch_softmax_online_multi_warp_scalar_kernel<16><<<batch_size, 16 * 32>>>(
+                d_input, d_output, batch_size, dim);
+        }
+    }
+    cudaCheckError(cudaGetLastError());
+}

--- a/cuda/batch_softmax/batch_softmax_online_multi_warp.h
+++ b/cuda/batch_softmax/batch_softmax_online_multi_warp.h
@@ -1,0 +1,62 @@
+#ifndef BATCH_SOFTMAX_ONLINE_MULTI_WARP_H
+#define BATCH_SOFTMAX_ONLINE_MULTI_WARP_H
+
+#include "batch_softmax_kernel.h"
+
+// Online multi-warp batch softmax with vectorized loads
+//
+// Combines the online softmax algorithm (single-pass statistics) with
+// multi-warp parallelism and float4 vectorized memory access.
+//
+// ONLINE SOFTMAX ALGORITHM:
+// -------------------------
+// Traditional two-pass:
+//   Pass 1: max = max(x_i)
+//   Pass 2: sum = Σ exp(x_i - max)
+//   Pass 3: output = exp(x - max) / sum
+//   Total: 3 memory passes
+//
+// Online single-pass (Milakov & Gimelshein, 2018):
+//   Pass 1: Compute (max, sum) together - for each x:
+//           old_max = max; max = fmaxf(max, x)
+//           sum = sum * exp(old_max - max) + exp(x - max)
+//   Pass 2: output = exp(x - max) / sum
+//   Total: 2 memory passes (saves one full read of input)
+//
+// MERGING (MAX, SUM) PAIRS:
+// -------------------------
+// When combining thread/warp states:
+//   merged_max = max(max1, max2)
+//   merged_sum = sum1 * exp(max1 - merged_max) + sum2 * exp(max2 - merged_max)
+//
+// ARCHITECTURE:
+// -------------
+// - Multiple warps per block (configurable: 4, 8, or 16 warps)
+// - Each warp maintains its own (max, sum) state during the online pass
+// - Warp-level reduction via shuffles (fast, no shared memory)
+// - Cross-warp reduction via shared memory (minimal: only num_warps values)
+// - Vectorized loads (float4) when dim % 4 == 0
+//
+// BENEFITS OVER MULTI-PASS:
+// -------------------------
+// - One fewer memory pass for statistics computation
+// - Better for memory-bound scenarios (large dims)
+// - Foundation for FlashAttention-style fused kernels
+//
+// TUNABLE PARAMETER:
+// - num_warps: Number of warps per block (4, 8, or 16)
+class OnlineMultiWarpBatchSoftmax : public BatchSoftmaxKernel {
+public:
+    // Constructor takes num_warps (4, 8, or 16)
+    OnlineMultiWarpBatchSoftmax(int batch_size, int dim, int num_warps);
+    void execute(const float *d_input, float *d_output) override;
+    ~OnlineMultiWarpBatchSoftmax() = default;
+
+private:
+    int batch_size;
+    int dim;
+    int num_warps;        // Number of warps per block (4, 8, or 16)
+    bool use_vectorized;  // True if dim % 4 == 0
+};
+
+#endif  // BATCH_SOFTMAX_ONLINE_MULTI_WARP_H


### PR DESCRIPTION
## Summary
- Add runtime autotuning for batch softmax kernels (naive, multi_warp, cub, cudnn, online_multi_warp) to find optimal configurations per input shape
- Template multi_warp kernel on WARPS_PER_BLOCK (4, 8, 16) for autotuning support
- Add online_multi_warp kernel combining single-pass online softmax algorithm with multi-warp parallelism and vectorized loads
- Update benchmark to show top 3 fastest kernels per shape

## Test plan
- [x] Build: `bazel build //cuda/batch_softmax:batch_softmax`
- [x] Run benchmark with all methods and verify output correctness against CPU reference
- [x] Verify autotuned variants perform >= default configurations
- [x] Verify online_multi_warp_tuned wins for large dimensions (512x16K: 0.037ms vs 0.040ms multi_warp_tuned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)