### PR TITLE
feat(project-euler): add PE22 and PE24

### DIFF
--- a/apps/project-euler/src/lib.rs
+++ b/apps/project-euler/src/lib.rs
@@ -2,8 +2,8 @@ pub mod solutions;
 
 /// Available problem IDs
 pub const PROBLEMS: &[u32] = &[
-    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 25, 26, 30, 34, 42,
-    50, 67, 74, 81,
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 30,
+    34, 42, 50, 67, 74, 81,
 ];
 
 /// Run a specific problem and return the answer
@@ -31,6 +31,8 @@ pub fn run_problem(id: u32, verbose: bool) -> Option<String> {
         19 => Some(solutions::pe19::solve(verbose)),
         20 => Some(solutions::pe20::solve(verbose)),
         21 => Some(solutions::pe21::solve(verbose)),
+        22 => Some(solutions::pe22::solve(verbose)),
+        24 => Some(solutions::pe24::solve(verbose)),
         25 => Some(solutions::pe25::solve(verbose)),
         26 => Some(solutions::pe26::solve(verbose)),
         30 => Some(solutions::pe30::solve(verbose)),

--- a/apps/project-euler/src/solutions/mod.rs
+++ b/apps/project-euler/src/solutions/mod.rs
@@ -12,6 +12,8 @@ pub mod pe19;
 pub mod pe2;
 pub mod pe20;
 pub mod pe21;
+pub mod pe22;
+pub mod pe24;
 pub mod pe25;
 pub mod pe26;
 pub mod pe3;

--- a/apps/project-euler/src/solutions/pe22.rs
+++ b/apps/project-euler/src/solutions/pe22.rs
@@ -1,0 +1,42 @@
+use std::fs;
+use std::path::PathBuf;
+
+pub fn solve(verbose: bool) -> String {
+    let data_path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "data", "names.txt"]
+        .iter()
+        .collect();
+    let content = fs::read_to_string(&data_path).expect("Failed to read names.txt");
+
+    let mut names: Vec<&str> = content.split(',').map(|s| s.trim_matches('"')).collect();
+
+    names.sort();
+
+    let mut total: u64 = 0;
+
+    for (i, name) in names.iter().enumerate() {
+        let position = (i + 1) as u64;
+        let alpha_value: u64 = name.chars().map(|c| (c as u64) - ('A' as u64) + 1).sum();
+        let score = alpha_value * position;
+
+        if verbose {
+            println!(
+                "{}: {} -> alpha={}, score={}",
+                position, name, alpha_value, score
+            );
+        }
+
+        total += score;
+    }
+
+    total.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_solve() {
+        assert_eq!(solve(false), "871198282");
+    }
+}

--- a/apps/project-euler/src/solutions/pe24.rs
+++ b/apps/project-euler/src/solutions/pe24.rs
@@ -1,0 +1,42 @@
+fn factorial(n: u64) -> u64 {
+    if n <= 1 { 1 } else { n * factorial(n - 1) }
+}
+
+pub fn solve(verbose: bool) -> String {
+    let mut available: Vec<u64> = (0..10).collect();
+    let mut remaining = 999_999u64;
+    let mut result = String::new();
+
+    for i in 0..10 {
+        let num_remaining_digits = 9 - i;
+        let fact = factorial(num_remaining_digits);
+        let index = remaining / fact;
+        remaining %= fact;
+
+        let digit = available.remove(index as usize);
+        result.push_str(&digit.to_string());
+
+        if verbose {
+            println!(
+                "Step {}: fact={}, index={}, picked={}, remaining={}",
+                i + 1,
+                fact,
+                index,
+                digit,
+                remaining
+            );
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_solve() {
+        assert_eq!(solve(false), "2783915460");
+    }
+}


### PR DESCRIPTION
## Summary

- Add PE22: Names Scores - parse names file, sort alphabetically, calculate scores based on position and letter values
- Add PE24: Lexicographic Permutations - find the millionth permutation of digits 0-9 using factorial-based indexing

## Test plan

- [x] `cargo test --package project-euler pe22` passes
- [x] `cargo test --package project-euler pe24` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)