### PR TITLE
feat(tinyllm): add LLaMA 1 model family (RMSNorm, RoPE, SwiGLU)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ halftone_web.log
 
 # ML models
 *.onnx
+/models/
 
 # Claude Code local settings
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ halftone_web.log
 
 # ML models
 *.onnx
-/models/
 
 # Claude Code local settings
 .claude/

--- a/ai/llm/tinyllm/BUILD.bazel
+++ b/ai/llm/tinyllm/BUILD.bazel
@@ -80,12 +80,15 @@ py_test(
 )
 
 # LLaMA model test
+# tagged "manual" because it downloads large weights (~6GB) and exceeds CI time limits
+# run locally with: bazel test //ai/llm/tinyllm:test_llama
 py_test(
     name = "test_llama",
     srcs = ["test_llama.py"],
     deps = [":tinyllm"],
-    size = "large",  # May download weights
-    timeout = "long",  # Allow time for download
+    size = "large",
+    timeout = "long",
+    tags = ["manual"],
 )
 
 # Interactive CLI

--- a/ai/llm/tinyllm/BUILD.bazel
+++ b/ai/llm/tinyllm/BUILD.bazel
@@ -8,10 +8,12 @@ py_library(
         "//ai/llm/tokenizer",
         "@pip//huggingface_hub",
         "@pip//numpy",
+        "@pip//protobuf",
         "@pip//safetensors",
+        "@pip//sentencepiece",
         "@pip//tiktoken",
         "@pip//tinygrad",
-        "@pip//transformers",  # For OPT tokenizer
+        "@pip//transformers",  # For OPT and LLaMA tokenizers
     ],
     visibility = ["//ai/llm/tinyllm:__subpackages__"],
 )
@@ -72,6 +74,15 @@ py_test(
 py_test(
     name = "test_opt",
     srcs = ["test_opt.py"],
+    deps = [":tinyllm"],
+    size = "large",  # May download weights
+    timeout = "long",  # Allow time for download
+)
+
+# LLaMA model test
+py_test(
+    name = "test_llama",
+    srcs = ["test_llama.py"],
     deps = [":tinyllm"],
     size = "large",  # May download weights
     timeout = "long",  # Allow time for download

--- a/ai/llm/tinyllm/__init__.py
+++ b/ai/llm/tinyllm/__init__.py
@@ -4,9 +4,9 @@ A minimal, educational LLM library using TinyGrad with zero PyTorch dependencies
 Provides clean implementations of LLM building blocks for multiple model families.
 """
 
-from .models import GPT2, OPT, BaseModel, GPT2Config, OPTConfig, generate
+from .models import GPT2, OPT, BaseModel, GPT2Config, LLaMA, LlamaConfig, OPTConfig, generate
 from .utils import load_weights
 
-__all__ = ["BaseModel", "load_weights", "GPT2", "GPT2Config", "OPT", "OPTConfig", "generate"]
+__all__ = ["BaseModel", "load_weights", "GPT2", "GPT2Config", "OPT", "OPTConfig", "LLaMA", "LlamaConfig", "generate"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/ai/llm/tinyllm/cli.py
+++ b/ai/llm/tinyllm/cli.py
@@ -5,7 +5,7 @@ import time
 import click
 from tinygrad import Tensor
 
-from ai.llm.tinyllm import GPT2, OPT, generate
+from ai.llm.tinyllm import GPT2, LLaMA, OPT, generate
 from ai.llm.tinyllm.models import BaseModel
 from ai.llm.tinyllm.utils import Tokenizer
 
@@ -14,6 +14,8 @@ def load_model(model_name: str) -> BaseModel:
     """Load model by name."""
     if model_name.startswith("facebook/opt-"):
         return OPT.from_pretrained(model_name)
+    elif model_name.startswith("openlm-research/") or "llama" in model_name.lower():
+        return LLaMA.from_pretrained(model_name)
     else:
         return GPT2.from_pretrained(model_name)
 
@@ -120,7 +122,7 @@ def run_prompt(
 @click.option("--max-tokens", default=50, help="Maximum tokens to generate")
 @click.option("--temperature", default=0.7, help="Sampling temperature")
 @click.option("--top-k", default=40, type=int, help="Top-k sampling")
-@click.option("--sample/--greedy", default=True, help="Use sampling or greedy decoding")
+@click.option("--sample/--greedy", default=False, help="Use sampling or greedy decoding")
 @click.option("--prompt", default=None, help="Prompt to run (non-interactive mode)")
 def main(model: str, max_tokens: int, temperature: float, top_k: int | None, sample: bool, prompt: str | None):
     """Interactive CLI for TinyLLM inference."""

--- a/ai/llm/tinyllm/cli.py
+++ b/ai/llm/tinyllm/cli.py
@@ -14,7 +14,7 @@ def load_model(model_name: str) -> BaseModel:
     """Load model by name."""
     if model_name.startswith("facebook/opt-"):
         return OPT.from_pretrained(model_name)
-    elif model_name.startswith("openlm-research/") or "llama" in model_name.lower():
+    elif model_name.startswith("openlm-research/") or model_name.startswith("meta-llama/") or "llama" in model_name.lower():
         return LLaMA.from_pretrained(model_name)
     else:
         return GPT2.from_pretrained(model_name)

--- a/ai/llm/tinyllm/cli.py
+++ b/ai/llm/tinyllm/cli.py
@@ -14,7 +14,11 @@ def load_model(model_name: str) -> BaseModel:
     """Load model by name."""
     if model_name.startswith("facebook/opt-"):
         return OPT.from_pretrained(model_name)
-    elif model_name.startswith("openlm-research/") or model_name.startswith("meta-llama/") or "llama" in model_name.lower():
+    elif (
+        model_name.startswith("openlm-research/")
+        or model_name.startswith("meta-llama/")
+        or "llama" in model_name.lower()
+    ):
         return LLaMA.from_pretrained(model_name)
     else:
         return GPT2.from_pretrained(model_name)

--- a/ai/llm/tinyllm/cli.py
+++ b/ai/llm/tinyllm/cli.py
@@ -5,7 +5,7 @@ import time
 import click
 from tinygrad import Tensor
 
-from ai.llm.tinyllm import GPT2, LLaMA, OPT, generate
+from ai.llm.tinyllm import GPT2, OPT, LLaMA, generate
 from ai.llm.tinyllm.models import BaseModel
 from ai.llm.tinyllm.utils import Tokenizer
 

--- a/ai/llm/tinyllm/models/__init__.py
+++ b/ai/llm/tinyllm/models/__init__.py
@@ -4,6 +4,7 @@ from .base import BaseModel
 from .config import GPT2Config
 from .generate import generate
 from .gpt2 import GPT2
+from .llama import LLaMA, LlamaConfig
 from .opt import OPT, OPTConfig
 
-__all__ = ["BaseModel", "GPT2Config", "GPT2", "OPTConfig", "OPT", "generate"]
+__all__ = ["BaseModel", "GPT2Config", "GPT2", "OPTConfig", "OPT", "LlamaConfig", "LLaMA", "generate"]

--- a/ai/llm/tinyllm/models/llama.py
+++ b/ai/llm/tinyllm/models/llama.py
@@ -40,6 +40,16 @@ class LlamaConfig:
         """Open LLaMA 13B (openlm-research/open_llama_13b)."""
         return cls(n_embd=5120, n_layer=40, n_head=40, n_inner=13824)
 
+    @classmethod
+    def llama2_7b(cls) -> "LlamaConfig":
+        """Meta LLaMA 2 7B (meta-llama/Llama-2-7b-hf)."""
+        return cls(n_positions=4096)
+
+    @classmethod
+    def llama2_13b(cls) -> "LlamaConfig":
+        """Meta LLaMA 2 13B (meta-llama/Llama-2-13b-hf)."""
+        return cls(n_embd=5120, n_layer=40, n_head=40, n_inner=13824, n_positions=4096)
+
 
 class _RopeCallable:
     """Wraps precomputed RoPE tables as a callable for CausalAttention."""
@@ -98,6 +108,8 @@ class LLaMA(BaseModel):
             "openlm-research/open_llama_3b": LlamaConfig.llama_3b,
             "openlm-research/open_llama_7b": LlamaConfig.llama_7b,
             "openlm-research/open_llama_13b": LlamaConfig.llama_13b,
+            "meta-llama/Llama-2-7b-hf": LlamaConfig.llama2_7b,
+            "meta-llama/Llama-2-13b-hf": LlamaConfig.llama2_13b,
         }
         config = config_map.get(model_name, LlamaConfig.llama_3b)()
         model = cls(config)

--- a/ai/llm/tinyllm/models/llama.py
+++ b/ai/llm/tinyllm/models/llama.py
@@ -1,0 +1,131 @@
+"""LLaMA 1 model implementation for TinyLLM."""
+
+from dataclasses import dataclass
+
+from tinygrad import Tensor
+from tinygrad.nn import Embedding, Linear
+
+from ..ops.attention import CausalAttention
+from ..ops.ffn import GatedFeedForward
+from ..ops.rmsnorm import RMSNorm
+from ..ops.rope import apply_rotary_emb, precompute_rope_freqs
+from .base import BaseModel
+
+
+@dataclass
+class LlamaConfig:
+    """Configuration for LLaMA model variants."""
+
+    vocab_size: int = 32000
+    n_positions: int = 2048
+    n_embd: int = 4096
+    n_layer: int = 32
+    n_head: int = 32
+    n_inner: int = 11008
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+
+    @classmethod
+    def llama_3b(cls) -> "LlamaConfig":
+        """Open LLaMA 3B (openlm-research/open_llama_3b)."""
+        return cls(n_embd=3200, n_layer=26, n_head=32, n_inner=8640)
+
+    @classmethod
+    def llama_7b(cls) -> "LlamaConfig":
+        """Open LLaMA 7B (openlm-research/open_llama_7b)."""
+        return cls()
+
+    @classmethod
+    def llama_13b(cls) -> "LlamaConfig":
+        """Open LLaMA 13B (openlm-research/open_llama_13b)."""
+        return cls(n_embd=5120, n_layer=40, n_head=40, n_inner=13824)
+
+
+class _RopeCallable:
+    """Wraps precomputed RoPE tables as a callable for CausalAttention."""
+
+    def __init__(self, cos: Tensor, sin: Tensor):
+        self.cos = cos
+        self.sin = sin
+
+    def __call__(self, q: Tensor, k: Tensor):
+        return apply_rotary_emb(q, k, self.cos, self.sin)
+
+
+class LlamaTransformerBlock:
+    """Single LLaMA transformer block with RMSNorm and SwiGLU FFN."""
+
+    def __init__(self, config: LlamaConfig, rope: _RopeCallable):
+        self.ln_1 = RMSNorm(config.n_embd, eps=config.rms_norm_eps)
+        self.attn = CausalAttention(config.n_embd, config.n_head, rope=rope, bias=False)
+        self.ln_2 = RMSNorm(config.n_embd, eps=config.rms_norm_eps)
+        self.mlp = GatedFeedForward(config.n_embd, config.n_inner)
+
+    def __call__(self, x: Tensor) -> Tensor:
+        x = x + self.attn(self.ln_1(x))
+        x = x + self.mlp(self.ln_2(x))
+        return x
+
+
+class LLaMA(BaseModel):
+    """LLaMA 1 Language Model."""
+
+    def __init__(self, config: LlamaConfig):
+        self.config = config
+        self.embed_tokens = Embedding(config.vocab_size, config.n_embd)
+
+        head_dim = config.n_embd // config.n_head
+        cos, sin = precompute_rope_freqs(head_dim, config.n_positions, config.rope_theta)
+        rope = _RopeCallable(cos, sin)
+
+        self.blocks = [LlamaTransformerBlock(config, rope) for _ in range(config.n_layer)]
+        self.ln_f = RMSNorm(config.n_embd, eps=config.rms_norm_eps)
+        self.lm_head = Linear(config.n_embd, config.vocab_size, bias=False)
+
+    def __call__(self, input_ids: Tensor) -> Tensor:
+        x = self.embed_tokens(input_ids)
+        for block in self.blocks:
+            x = block(x)
+        x = self.ln_f(x)
+        return self.lm_head(x)
+
+    @classmethod
+    def from_pretrained(cls, model_name: str = "openlm-research/open_llama_3b") -> "LLaMA":
+        """Load pre-trained LLaMA model from HuggingFace."""
+        from ..utils import load_weights
+
+        config_map = {
+            "openlm-research/open_llama_3b": LlamaConfig.llama_3b,
+            "openlm-research/open_llama_7b": LlamaConfig.llama_7b,
+            "openlm-research/open_llama_13b": LlamaConfig.llama_13b,
+        }
+        config = config_map.get(model_name, LlamaConfig.llama_3b)()
+        model = cls(config)
+        _load_llama_weights(model, load_weights(model_name))
+        return model
+
+
+def _load_llama_weights(model: LLaMA, weights: dict[str, Tensor]) -> None:
+    """
+    Load HuggingFace LLaMA weights into model.
+
+    LLaMA uses standard Linear format — no transposition needed.
+    No biases anywhere.
+    """
+    model.embed_tokens.weight = weights["model.embed_tokens.weight"]
+
+    for i, block in enumerate(model.blocks):
+        prefix = f"model.layers.{i}."
+
+        block.ln_1.weight = weights[f"{prefix}input_layernorm.weight"]
+        block.attn.q_proj.weight = weights[f"{prefix}self_attn.q_proj.weight"]
+        block.attn.k_proj.weight = weights[f"{prefix}self_attn.k_proj.weight"]
+        block.attn.v_proj.weight = weights[f"{prefix}self_attn.v_proj.weight"]
+        block.attn.out_proj.weight = weights[f"{prefix}self_attn.o_proj.weight"]
+        block.ln_2.weight = weights[f"{prefix}post_attention_layernorm.weight"]
+        block.mlp.gate_proj.weight = weights[f"{prefix}mlp.gate_proj.weight"]
+        block.mlp.up_proj.weight = weights[f"{prefix}mlp.up_proj.weight"]
+        block.mlp.down_proj.weight = weights[f"{prefix}mlp.down_proj.weight"]
+
+    model.ln_f.weight = weights["model.norm.weight"]
+    model.lm_head.weight = weights["lm_head.weight"]

--- a/ai/llm/tinyllm/models/llama.py
+++ b/ai/llm/tinyllm/models/llama.py
@@ -26,17 +26,17 @@ class LlamaConfig:
     rope_theta: float = 10000.0
 
     @classmethod
-    def llama_3b(cls) -> "LlamaConfig":
+    def open_llama_3b(cls) -> "LlamaConfig":
         """Open LLaMA 3B (openlm-research/open_llama_3b)."""
         return cls(n_embd=3200, n_layer=26, n_head=32, n_inner=8640)
 
     @classmethod
-    def llama_7b(cls) -> "LlamaConfig":
+    def open_llama_7b(cls) -> "LlamaConfig":
         """Open LLaMA 7B (openlm-research/open_llama_7b)."""
         return cls()
 
     @classmethod
-    def llama_13b(cls) -> "LlamaConfig":
+    def open_llama_13b(cls) -> "LlamaConfig":
         """Open LLaMA 13B (openlm-research/open_llama_13b)."""
         return cls(n_embd=5120, n_layer=40, n_head=40, n_inner=13824)
 
@@ -105,13 +105,16 @@ class LLaMA(BaseModel):
         from ..utils import load_weights
 
         config_map = {
-            "openlm-research/open_llama_3b": LlamaConfig.llama_3b,
-            "openlm-research/open_llama_7b": LlamaConfig.llama_7b,
-            "openlm-research/open_llama_13b": LlamaConfig.llama_13b,
+            "openlm-research/open_llama_3b": LlamaConfig.open_llama_3b,
+            "openlm-research/open_llama_7b": LlamaConfig.open_llama_7b,
+            "openlm-research/open_llama_13b": LlamaConfig.open_llama_13b,
             "meta-llama/Llama-2-7b-hf": LlamaConfig.llama2_7b,
             "meta-llama/Llama-2-13b-hf": LlamaConfig.llama2_13b,
         }
-        config = config_map.get(model_name, LlamaConfig.llama_3b)()
+        config_fn = config_map.get(model_name)
+        if config_fn is None:
+            raise ValueError(f"Unsupported LLaMA model: {model_name}. Supported: {list(config_map.keys())}")
+        config = config_fn()
         model = cls(config)
         _load_llama_weights(model, load_weights(model_name))
         return model

--- a/ai/llm/tinyllm/ops/__init__.py
+++ b/ai/llm/tinyllm/ops/__init__.py
@@ -1,15 +1,22 @@
 """Building block operations for TinyLLM."""
 
-from .activations import gelu, relu
+from .activations import gelu, relu, silu
 from .attention import CausalAttention
 from .embeddings import OPTEmbedding, TokenPositionEmbedding
-from .ffn import FeedForward
+from .ffn import FeedForward, GatedFeedForward
+from .rmsnorm import RMSNorm
+from .rope import apply_rotary_emb, precompute_rope_freqs
 
 __all__ = [
     "gelu",
     "relu",
+    "silu",
     "CausalAttention",
     "TokenPositionEmbedding",
     "OPTEmbedding",
     "FeedForward",
+    "GatedFeedForward",
+    "RMSNorm",
+    "apply_rotary_emb",
+    "precompute_rope_freqs",
 ]

--- a/ai/llm/tinyllm/ops/activations.py
+++ b/ai/llm/tinyllm/ops/activations.py
@@ -34,3 +34,20 @@ def relu(x: Tensor) -> Tensor:
         Activated tensor
     """
     return x.relu()
+
+
+def silu(x: Tensor) -> Tensor:
+    """
+    Sigmoid Linear Unit activation.
+
+    SiLU(x) = x * sigmoid(x)
+
+    Used in LLaMA's SwiGLU feed-forward network.
+
+    Args:
+        x: Input tensor
+
+    Returns:
+        Activated tensor
+    """
+    return x * x.sigmoid()

--- a/ai/llm/tinyllm/ops/attention.py
+++ b/ai/llm/tinyllm/ops/attention.py
@@ -9,15 +9,16 @@ from tinygrad.nn import Linear
 class CausalAttention:
     """Multi-head causal self-attention with separate Q, K, V projections."""
 
-    def __init__(self, embed_dim: int, num_heads: int):
+    def __init__(self, embed_dim: int, num_heads: int, rope=None, bias: bool = True):
         self.num_heads = num_heads
         self.head_dim = embed_dim // num_heads
         self.embed_dim = embed_dim
+        self.rope = rope
 
-        self.q_proj = Linear(embed_dim, embed_dim)
-        self.k_proj = Linear(embed_dim, embed_dim)
-        self.v_proj = Linear(embed_dim, embed_dim)
-        self.out_proj = Linear(embed_dim, embed_dim)
+        self.q_proj = Linear(embed_dim, embed_dim, bias=bias)
+        self.k_proj = Linear(embed_dim, embed_dim, bias=bias)
+        self.v_proj = Linear(embed_dim, embed_dim, bias=bias)
+        self.out_proj = Linear(embed_dim, embed_dim, bias=bias)
 
     def __call__(self, x: Tensor) -> Tensor:
         batch_size, seq_len, _ = x.shape
@@ -30,6 +31,9 @@ class CausalAttention:
         q = q.reshape(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
         k = k.reshape(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
         v = v.reshape(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+
+        if self.rope is not None:
+            q, k = self.rope(q, k)
 
         # Scaled dot-product attention with causal mask
         scale = 1.0 / math.sqrt(self.head_dim)

--- a/ai/llm/tinyllm/ops/ffn.py
+++ b/ai/llm/tinyllm/ops/ffn.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from tinygrad import Tensor
 from tinygrad.nn import Linear
 
-from .activations import gelu
+from .activations import gelu, silu
 
 
 class FeedForward:
@@ -18,3 +18,15 @@ class FeedForward:
 
     def __call__(self, x: Tensor) -> Tensor:
         return self.fc2(self.activation(self.fc1(x)))
+
+
+class GatedFeedForward:
+    """SwiGLU gated feed-forward network used in LLaMA."""
+
+    def __init__(self, embed_dim: int, hidden_dim: int):
+        self.gate_proj = Linear(embed_dim, hidden_dim, bias=False)
+        self.up_proj = Linear(embed_dim, hidden_dim, bias=False)
+        self.down_proj = Linear(hidden_dim, embed_dim, bias=False)
+
+    def __call__(self, x: Tensor) -> Tensor:
+        return self.down_proj(silu(self.gate_proj(x)) * self.up_proj(x))

--- a/ai/llm/tinyllm/ops/rmsnorm.py
+++ b/ai/llm/tinyllm/ops/rmsnorm.py
@@ -1,0 +1,15 @@
+"""RMSNorm for TinyLLM."""
+
+from tinygrad import Tensor
+
+
+class RMSNorm:
+    """Root Mean Square Layer Normalization (no bias, scale only)."""
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        self.weight = Tensor.ones(dim)
+        self.eps = eps
+
+    def __call__(self, x: Tensor) -> Tensor:
+        rms = (x.pow(2).mean(-1, keepdim=True) + self.eps).sqrt()
+        return (x / rms) * self.weight

--- a/ai/llm/tinyllm/ops/rope.py
+++ b/ai/llm/tinyllm/ops/rope.py
@@ -1,0 +1,54 @@
+"""Rotary Position Embeddings (RoPE) for TinyLLM."""
+
+from tinygrad import Tensor
+
+
+def precompute_rope_freqs(head_dim: int, max_seq_len: int, theta: float = 10000.0):
+    """
+    Precompute cos/sin tables for RoPE.
+
+    Args:
+        head_dim: Dimension of each attention head.
+        max_seq_len: Maximum sequence length.
+        theta: Base frequency (default 10000.0).
+
+    Returns:
+        Tuple of (cos, sin) tensors, each shape (max_seq_len, head_dim // 2).
+    """
+    half_dim = head_dim // 2
+    freqs = 1.0 / (theta ** (Tensor.arange(0, half_dim).float() / half_dim))
+    positions = Tensor.arange(0, max_seq_len).float()
+    # Outer product: (max_seq_len, half_dim)
+    angles = positions.reshape(max_seq_len, 1) * freqs.reshape(1, half_dim)
+    return angles.cos(), angles.sin()
+
+
+def apply_rotary_emb(q: Tensor, k: Tensor, cos: Tensor, sin: Tensor):
+    """
+    Apply rotary position embeddings to query and key tensors.
+
+    Args:
+        q: Query tensor, shape (batch, heads, seq_len, head_dim).
+        k: Key tensor, shape (batch, heads, seq_len, head_dim).
+        cos: Cosine table, shape (max_seq_len, head_dim // 2).
+        sin: Sine table, shape (max_seq_len, head_dim // 2).
+
+    Returns:
+        Tuple of rotated (q, k).
+    """
+    seq_len = q.shape[2]
+    cos = cos[:seq_len]  # (seq_len, half_dim)
+    sin = sin[:seq_len]
+
+    # Reshape for broadcasting: (1, 1, seq_len, half_dim)
+    cos = cos.reshape(1, 1, seq_len, cos.shape[-1])
+    sin = sin.reshape(1, 1, seq_len, sin.shape[-1])
+
+    def rotate(x: Tensor) -> Tensor:
+        half = x.shape[-1] // 2
+        x1 = x[..., :half]
+        x2 = x[..., half:]
+        # Rotation: [x1, x2] -> [x1*cos - x2*sin, x2*cos + x1*sin]
+        return Tensor.cat(x1 * cos - x2 * sin, x2 * cos + x1 * sin, dim=-1)
+
+    return rotate(q), rotate(k)

--- a/ai/llm/tinyllm/test_llama.py
+++ b/ai/llm/tinyllm/test_llama.py
@@ -2,7 +2,6 @@
 
 import time
 
-import numpy as np
 from tinygrad import Tensor
 
 from ai.llm.tinyllm import LLaMA, LlamaConfig, generate

--- a/ai/llm/tinyllm/test_llama.py
+++ b/ai/llm/tinyllm/test_llama.py
@@ -1,0 +1,113 @@
+"""Tests for LLaMA model implementation."""
+
+import time
+
+import numpy as np
+from tinygrad import Tensor
+
+from ai.llm.tinyllm import LLaMA, LlamaConfig, generate
+
+
+def test_config():
+    """Test LlamaConfig fields."""
+    config = LlamaConfig.llama_3b()
+    assert config.n_layer == 26
+    assert config.n_head == 32
+    assert config.n_embd == 3200
+    assert config.n_inner == 8640
+    assert config.vocab_size == 32000
+    assert config.n_positions == 2048
+    assert config.rms_norm_eps == 1e-6
+    assert config.rope_theta == 10000.0
+    print("Config 3B test passed")
+
+    config_7b = LlamaConfig.llama_7b()
+    assert config_7b.n_layer == 32
+    assert config_7b.n_head == 32
+    assert config_7b.n_embd == 4096
+    assert config_7b.n_inner == 11008
+    print("Config 7B test passed")
+
+    config_13b = LlamaConfig.llama_13b()
+    assert config_13b.n_layer == 40
+    assert config_13b.n_head == 40
+    assert config_13b.n_embd == 5120
+    assert config_13b.n_inner == 13824
+    print("Config 13B test passed")
+
+
+def test_forward_pass():
+    """Test model forward pass with random weights."""
+    config = LlamaConfig.llama_3b()
+    model = LLaMA(config)
+
+    batch_size, seq_len = 2, 10
+    input_ids = Tensor([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]])
+
+    logits = model(input_ids)
+
+    assert logits.shape == (batch_size, seq_len, config.vocab_size), (
+        f"Expected {(batch_size, seq_len, config.vocab_size)}, got {logits.shape}"
+    )
+    print(f"Forward pass test passed: output shape {logits.shape}")
+
+
+def test_pretrained_loading():
+    """Test loading pre-trained Open LLaMA 3B weights."""
+    print("Loading openlm-research/open_llama_3b from HuggingFace...")
+    start = time.time()
+    model = LLaMA.from_pretrained("openlm-research/open_llama_3b")
+    load_time = time.time() - start
+    print(f"Loaded in {load_time:.2f}s")
+
+    input_ids = Tensor([[1, 9038, 2501, 263, 931]])  # "Once upon a time" approx
+    logits = model(input_ids)
+
+    assert logits.shape == (1, 5, 32000)
+    print("Pretrained loading test passed")
+
+
+def test_generation_greedy():
+    """Test greedy text generation."""
+    model = LLaMA.from_pretrained("openlm-research/open_llama_3b")
+
+    input_ids = Tensor([[1]])  # BOS token
+
+    output = generate(model, input_ids, max_new_tokens=5, do_sample=False)
+    assert output.shape[1] == 6  # 1 input + 5 generated
+    print(f"Greedy generation test passed: generated {output.shape[1]} tokens")
+    print(f"Token IDs: {output.numpy()}")
+
+
+def test_generation_sampling():
+    """Test sampling-based text generation."""
+    model = LLaMA.from_pretrained("openlm-research/open_llama_3b")
+
+    input_ids = Tensor([[1]])  # BOS token
+
+    output = generate(model, input_ids, max_new_tokens=5, do_sample=True, temperature=0.8)
+    assert output.shape[1] == 6  # 1 input + 5 generated
+    print(f"Sampling generation test passed: generated {output.shape[1]} tokens")
+    print(f"Token IDs: {output.numpy()}")
+
+
+def test_generation_top_k():
+    """Test top-k sampling."""
+    model = LLaMA.from_pretrained("openlm-research/open_llama_3b")
+
+    input_ids = Tensor([[1]])  # BOS token
+
+    output = generate(model, input_ids, max_new_tokens=5, do_sample=True, top_k=50, temperature=0.8)
+    assert output.shape[1] == 6  # 1 input + 5 generated
+    print(f"Top-k sampling test passed: generated {output.shape[1]} tokens")
+    print(f"Token IDs: {output.numpy()}")
+
+
+if __name__ == "__main__":
+    test_config()
+    test_forward_pass()
+    test_pretrained_loading()
+    test_generation_greedy()
+    test_generation_sampling()
+    test_generation_top_k()
+    print("\nAll tests passed!")

--- a/ai/llm/tinyllm/test_llama.py
+++ b/ai/llm/tinyllm/test_llama.py
@@ -10,7 +10,7 @@ from ai.llm.tinyllm import LLaMA, LlamaConfig, generate
 
 def test_config():
     """Test LlamaConfig fields."""
-    config = LlamaConfig.llama_3b()
+    config = LlamaConfig.open_llama_3b()
     assert config.n_layer == 26
     assert config.n_head == 32
     assert config.n_embd == 3200
@@ -21,14 +21,14 @@ def test_config():
     assert config.rope_theta == 10000.0
     print("Config 3B test passed")
 
-    config_7b = LlamaConfig.llama_7b()
+    config_7b = LlamaConfig.open_llama_7b()
     assert config_7b.n_layer == 32
     assert config_7b.n_head == 32
     assert config_7b.n_embd == 4096
     assert config_7b.n_inner == 11008
     print("Config 7B test passed")
 
-    config_13b = LlamaConfig.llama_13b()
+    config_13b = LlamaConfig.open_llama_13b()
     assert config_13b.n_layer == 40
     assert config_13b.n_head == 40
     assert config_13b.n_embd == 5120
@@ -38,7 +38,7 @@ def test_config():
 
 def test_forward_pass():
     """Test model forward pass with random weights."""
-    config = LlamaConfig.llama_3b()
+    config = LlamaConfig.open_llama_3b()
     model = LLaMA(config)
 
     batch_size, seq_len = 2, 10

--- a/ai/llm/tokenizer/tokenizer.py
+++ b/ai/llm/tokenizer/tokenizer.py
@@ -69,5 +69,9 @@ class Tokenizer:
         if model_name.startswith("facebook/opt-"):
             return cls(model_name, "huggingface")
 
+        # LLaMA models use HuggingFace tokenizer (SentencePiece via transformers)
+        if model_name.startswith("openlm-research/") or "llama" in model_name.lower():
+            return cls(model_name, "huggingface")
+
         # Default to tiktoken gpt2
         return cls("gpt2", "tiktoken")

--- a/ai/llm/tokenizer/tokenizer.py
+++ b/ai/llm/tokenizer/tokenizer.py
@@ -70,7 +70,7 @@ class Tokenizer:
             return cls(model_name, "huggingface")
 
         # LLaMA models use HuggingFace tokenizer (SentencePiece via transformers)
-        if model_name.startswith("openlm-research/") or "llama" in model_name.lower():
+        if model_name.startswith("openlm-research/") or model_name.startswith("meta-llama/") or "llama" in model_name.lower():
             return cls(model_name, "huggingface")
 
         # Default to tiktoken gpt2

--- a/ai/llm/tokenizer/tokenizer.py
+++ b/ai/llm/tokenizer/tokenizer.py
@@ -70,7 +70,11 @@ class Tokenizer:
             return cls(model_name, "huggingface")
 
         # LLaMA models use HuggingFace tokenizer (SentencePiece via transformers)
-        if model_name.startswith("openlm-research/") or model_name.startswith("meta-llama/") or "llama" in model_name.lower():
+        if (
+            model_name.startswith("openlm-research/")
+            or model_name.startswith("meta-llama/")
+            or "llama" in model_name.lower()
+        ):
             return cls(model_name, "huggingface")
 
         # Default to tiktoken gpt2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ huggingface_hub
 safetensors
 tiktoken
 transformers>=4.40.0  # For OPT tokenizer (need newer version for pre-built wheels)
+protobuf  # For LLaMA SentencePiece tokenizer
+sentencepiece  # For LLaMA tokenizer

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -31,6 +31,8 @@ packaging==25.0
     #   transformers
 pillow==12.1.0
     # via -r requirements.txt
+protobuf==7.34.0
+    # via -r requirements.txt
 pyyaml==6.0.3
     # via
     #   huggingface-hub
@@ -48,6 +50,8 @@ safetensors==0.7.0
     # via
     #   -r requirements.txt
     #   transformers
+sentencepiece==0.2.1
+    # via -r requirements.txt
 tiktoken==0.12.0
     # via -r requirements.txt
 tinygrad==0.11.0


### PR DESCRIPTION
## Summary

- Adds LLaMA 1 as the third model family in TinyLLM, targeting `openlm-research/open_llama_{3b,7b,13b}` (Apache 2.0)
- Introduces three new ops that are the foundation of virtually all modern open-weights models: **RMSNorm**, **RoPE**, and **SwiGLU**
- `CausalAttention` gains optional `rope` and `bias` params — GPT-2 and OPT are unaffected (defaults to `rope=None, bias=True`)
- Extends tokenizer routing and Bazel deps (`protobuf`, `sentencepiece`) for LLaMA's SentencePiece tokenizer
- Default CLI decoding switched from sampling to greedy for consistent, loop-free output

## Verified working

```
$ bazel run //ai/llm/tinyllm:cli -- --model openlm-research/open_llama_3b --prompt "The capital of France is" --max-tokens 20

The capital of France is Paris.
The French Republic is a sovereign state in Western Europe. The French Republic is a

Stats:
  Input tokens:  5
  Output tokens: 20
  Tokens/sec:    12.9
```

## Test plan

- [ ] `bazel test //ai/llm/tinyllm:test_llama --test_output=streamed`
- [ ] `bazel test //ai/llm/tinyllm:test_gpt2` (regression)
- [ ] `bazel test //ai/llm/tinyllm:test_opt` (regression)
- [ ] `bazel run //ai/llm/tinyllm:cli -- --model openlm-research/open_llama_3b --prompt "..." --max-tokens 30`

🤖 Generated with [Claude Code](https://claude.com/claude-code)