### PR TITLE
fix(tinyllm): fix .bin weight loading and OPT key prefix detection

### DIFF
--- a/ai/llm/tinyllm/models/opt.py
+++ b/ai/llm/tinyllm/models/opt.py
@@ -111,17 +111,20 @@ def _load_opt_weights(model: OPT, weights: dict[str, Tensor]) -> None:
     Load HuggingFace OPT weights into model.
 
     OPT uses standard Linear format (out_features, in_features) — no transposition needed.
+    Different checkpoints use either "model.decoder.*" or bare "decoder.*" key prefixes.
     """
-    model.embeddings.embed_tokens.weight = weights["model.decoder.embed_tokens.weight"]
-    model.embeddings.embed_positions.weight = weights["model.decoder.embed_positions.weight"]
+    # Detect key prefix: some checkpoints use "model.decoder.*", others bare "decoder.*"
+    pfx = "model.decoder" if "model.decoder.embed_tokens.weight" in weights else "decoder"
+    model.embeddings.embed_tokens.weight = weights[f"{pfx}.embed_tokens.weight"]
+    model.embeddings.embed_positions.weight = weights[f"{pfx}.embed_positions.weight"]
 
     if model.embeddings.project_in is not None:
-        model.embeddings.project_in.weight = weights["model.decoder.project_in.weight"]
+        model.embeddings.project_in.weight = weights[f"{pfx}.project_in.weight"]
     if model.embeddings.project_out is not None:
-        model.embeddings.project_out.weight = weights["model.decoder.project_out.weight"]
+        model.embeddings.project_out.weight = weights[f"{pfx}.project_out.weight"]
 
     for i, block in enumerate(model.blocks):
-        prefix = f"model.decoder.layers.{i}."
+        prefix = f"{pfx}.layers.{i}."
 
         block.self_attn_layer_norm.weight = weights[f"{prefix}self_attn_layer_norm.weight"]
         block.self_attn_layer_norm.bias = weights[f"{prefix}self_attn_layer_norm.bias"]
@@ -143,8 +146,8 @@ def _load_opt_weights(model: OPT, weights: dict[str, Tensor]) -> None:
         block.mlp.fc2.weight = weights[f"{prefix}fc2.weight"]
         block.mlp.fc2.bias = weights[f"{prefix}fc2.bias"]
 
-    model.final_layer_norm.weight = weights["model.decoder.final_layer_norm.weight"]
-    model.final_layer_norm.bias = weights["model.decoder.final_layer_norm.bias"]
+    model.final_layer_norm.weight = weights[f"{pfx}.final_layer_norm.weight"]
+    model.final_layer_norm.bias = weights[f"{pfx}.final_layer_norm.bias"]
 
     model.lm_head.weight = weights["lm_head.weight"]
     if "lm_head.bias" in weights:

--- a/ai/llm/tinyllm/utils/weights.py
+++ b/ai/llm/tinyllm/utils/weights.py
@@ -34,14 +34,13 @@ def load_weights(model_name: str) -> dict[str, Tensor]:
     weights = _load_weights_from_dir(cache_dir)
 
     # Convert to TinyGrad tensors on the default device
-    import os
     result = {}
     for name, val in weights.items():
         if isinstance(val, Tensor):
-            # CPU tensor from torch_load (.bin format) — copy to default device
-            target_device = "CUDA:0" if os.environ.get("CUDA") else "CPU"
-            result[name] = val.to(target_device)
+            # DISK-backed tensor from torch_load (.bin) — copy to default device
+            result[name] = val.to(Device.DEFAULT)
         else:
+            # Numpy array from safetensors — create tensor on default device
             result[name] = Tensor(val)
     return result
 

--- a/ai/llm/tinyllm/utils/weights.py
+++ b/ai/llm/tinyllm/utils/weights.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from tinygrad import Tensor

--- a/ai/llm/tinyllm/utils/weights.py
+++ b/ai/llm/tinyllm/utils/weights.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from huggingface_hub import snapshot_download
 from safetensors import safe_open
-from tinygrad import Tensor
+from tinygrad import Device, Tensor
 from tinygrad.nn.state import torch_load
 
 

--- a/ai/llm/tinyllm/utils/weights.py
+++ b/ai/llm/tinyllm/utils/weights.py
@@ -33,8 +33,17 @@ def load_weights(model_name: str) -> dict[str, Tensor]:
     # Try safetensors first, fall back to PyTorch bin
     weights = _load_weights_from_dir(cache_dir)
 
-    # Convert to TinyGrad tensors
-    return {name: Tensor(arr) for name, arr in weights.items()}
+    # Convert to TinyGrad tensors on the default device
+    import os
+    result = {}
+    for name, val in weights.items():
+        if isinstance(val, Tensor):
+            # CPU tensor from torch_load (.bin format) — copy to default device
+            target_device = "CUDA:0" if os.environ.get("CUDA") else "CPU"
+            result[name] = val.to(target_device)
+        else:
+            result[name] = Tensor(val)
+    return result
 
 
 def _download_from_hf(model_name: str) -> Path:
@@ -125,19 +134,11 @@ def _load_pickle_bin(cache_dir: Path) -> dict[str, Any]:
     # Find all .bin files
     bin_files = sorted(cache_dir.glob("*.bin"))
 
-    # Load each file with tinygrad's torch_load (no torch dependency)
-    # We need to pass a Tensor created from bytes to avoid disk device permission issues
+    # Load each file with tinygrad's torch_load using DISK device (no CPU compilation needed)
     for file in bin_files:
-        # Read file into memory first to avoid permission issues with disk tensors
-        with open(file, "rb") as f:
-            file_bytes = f.read()
-        # Create in-memory tensor from bytes and pass to torch_load
-        # Use bytearray to create a writable buffer (np.frombuffer is read-only)
-        # Keep on CPU to avoid GPU OOM for large models
-        file_array = np.array(bytearray(file_bytes), dtype=np.uint8)
-        file_tensor = Tensor(file_array, device="CPU")
-        state_dict = torch_load(file_tensor)
+        # Pass path directly — torch_load uses DISK device, avoiding CPU/clang compilation
+        state_dict = torch_load(str(file))
         for key, tensor in state_dict.items():
-            weights[key] = tensor.numpy()
+            weights[key] = tensor  # DISK-backed tensor, moved to target device later
 
     return weights


### PR DESCRIPTION
## Summary

- **Fix .bin weight loading on systems without clang**: The old  implementation read each  file into an in-memory CPU tensor and called  on the resulting weights. This triggered tinygrad's CPU compiler which requires  (not always available). Fixed by passing the file path directly to , which uses tinygrad's  device and avoids CPU compilation entirely.

- **Fix OPT weight key prefix detection**: Different OPT checkpoints use different key prefixes —  uses  but  uses bare . The loader now auto-detects the correct prefix by checking which format is present in the weight dict.

## Test plan

- [x] Tested  — loads and generates correctly
- [x] Tested  — loads and generates correctly  
- [x] Tested all GPT-2 variants (gpt2, gpt2-medium, gpt2-large, gpt2-xl) — unaffected (use safetensors)
- [x] Tested  and  — loads and generates correctly
- [ ]  still fails — checkpoint appears to use weight tying (no top-level  or ), separate fix needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)